### PR TITLE
Add --type opt to differentiate Hardware and VM's

### DIFF
--- a/check_softlayer_transfer
+++ b/check_softlayer_transfer
@@ -11,7 +11,7 @@
 # it is the monthly outbound data transfer allotment. I try to use the
 # correct term "transfer" when not referring to SoftLayer API names etc.
 #
-# Copyright © 2012-2013 End Point Corporation, http://www.endpoint.com/
+# Copyright © 2012-2014 End Point Corporation, http://www.endpoint.com/
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,7 +34,7 @@ use LWP::UserAgent;
 use JSON;
 use List::Util qw( max );
 
-our $VERSION = '0.2';
+our $VERSION = '0.3';
 
 
 #
@@ -111,7 +111,7 @@ my $dom = $timeinfo[3];
 # Make web service calls
 #
 
-my $ua = LWP::UserAgent->new(agent => 'endpoint-bandwidth-bot/0.1');
+my $ua = LWP::UserAgent->new(agent => "endpoint-bandwidth-bot/$VERSION");
 $ua->default_header('Accept-Encoding' => scalar HTTP::Message::decodable());
 $ua->timeout($opt{timeout}) if $opt{timeout};
 


### PR DESCRIPTION
Previously the script combined both Hardware and VirtualGuests lists
into a single one.  But subsequent API calls for the two server types
are slightly different.

The -T option, set to "Hardware" by default for backward compatibility,
will fetch the desired list, and call the correct API target based on
that type.  This also works with --list.
